### PR TITLE
fix: cms input cursor bug

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -5,6 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="app.css" />
     <title>Hugolify - Content Manager</title>
+    <style>
+      /** Workaround to fix https://github.com/decaporg/decap-cms/issues/5092#issuecomment-1256321540 **/
+      [data-slate-editor] { 
+          -webkit-user-modify: read-write !important; 
+      }
+    </style>
   </head>
   <body>
     <!-- Include the script that enables Netlify Identity on this page. -->


### PR DESCRIPTION
Le curseur va en fin de ligne lorsqu'on édite le milieu d'un texte,
C'est un problème toujours pas corrigé et connu, un workaround existe.

Cette MR vise à utiliser ce workaround.

Plus de détails sur l'issue ici:
See decaporg/decap-cms#5092